### PR TITLE
Criação de API falecidos covid e API todos docentes

### DIFF
--- a/app/Http/Controllers/Api/PessoaController.php
+++ b/app/Http/Controllers/Api/PessoaController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Pessoa;
+use App\Models\Lattes;
 use App\Http\Requests\PessoaRequest;
 
 class PessoaController extends Controller
@@ -14,17 +15,34 @@ class PessoaController extends Controller
             Pessoa::listar($request->validated())
         );
     }
-    
 
     public function listarFalecidosPorPeriodo(PessoaRequest $request){
+        $falecidos = Pessoa::whereBetween('dtaflc', [$request->dtaini, $request->dtafim])->get()->toArray();
+        
         return response()->json(
-            \Uspdev\Replicado\Pessoa::listarFalecidosPorPeriodo($request->dtaini, $request->dtafim)
+            $falecidos            
         );
     }
 
     public function listarDocentes(){
+        $docentes = Pessoa::where('tipo_vinculo', 'Docente')->get()->toArray();
+        $resultado = [];
+
+        foreach($docentes as $docente){
+            $lattes = Lattes::where('codpes', $docente['codpes'])->first();
+            
+            if($lattes != NULL){
+                $lattes = $lattes->toArray();
+                if(isset($lattes['json']) && $lattes['json'] != NULL && $lattes['json'] != ''){
+                    $json = json_decode($lattes['json']);
+                    $docente['id_lattes'] = $json->id_lattes;
+                }
+            } 
+            array_push($resultado, $docente);
+        }
+        
         return response()->json(
-            \Uspdev\Replicado\Pessoa::listarTodosDocentes()
+            $resultado
         );
     }
 

--- a/app/Models/Pessoa.php
+++ b/app/Models/Pessoa.php
@@ -26,7 +26,7 @@ class Pessoa extends Model
     }
 
     public static function listarDocentes(){
-        $retorno = ReplicadoPessoa::listarTodosDocentes();
+        $retorno = ReplicadoPessoa::listarDocentes(null, 'A,P');
         $docentes = [];
         foreach($retorno as $docente){
             $aux = [];

--- a/database/migrations/2021_05_04_225301_create_pessoas_table.php
+++ b/database/migrations/2021_05_04_225301_create_pessoas_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePessoasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('pessoas', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->integer('codpes');
+            $table->string('nompes');
+            $table->date('dtanas')->nullable();
+            $table->date('dtaflc')->nullable();
+            $table->string('sexpes')->nullable();
+            $table->string('nomset')->nullable();
+            $table->string('email')->nullable();
+            $table->string('codset')->nullable();
+            $table->string('sitatl')->nullable();
+            $table->integer('id_lattes')->nullable();
+            $table->string('tipo_vinculo')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('pessoas');
+    }
+}


### PR DESCRIPTION
 A API dos falecidos retorna falecidos da FFLCH no período da Covid, para serem usados no site memorial da FFLCH. Para isso, foi feita uma nova tabela chamada 'pessoas', com os campos necessários a serem retornados, como data de nascimento e de falecimento).
Além disso, a API docentes retorna todos os docentes da faculdade, sendo eles Ativos ou Aposentados, também será utilizada no site Docentes da fflch.