### PR TITLE
Otimizando consulta de alunos ativos autodeclarados

### DIFF
--- a/Queries/conta_alunos_autodeclarados.sql
+++ b/Queries/conta_alunos_autodeclarados.sql
@@ -2,7 +2,7 @@ SELECT COUNT(l.codpes)
 FROM LOCALIZAPESSOA l
     JOIN COMPLPESSOA c
     ON c.codpes = l.codpes
-WHERE l.tipvin IN ('ALUNOGR', 'ALUNOCEU', 'ALUNOPOS', 'ALUNOPD')
+WHERE l.tipvin = '__vinculo__'
     AND l.codundclg = 8
     AND l.sitatl = 'A'
     AND c.codraccor = __cor__

--- a/app/Http/Controllers/AlunosAtivosAutodeclaradosController.php
+++ b/app/Http/Controllers/AlunosAtivosAutodeclaradosController.php
@@ -21,9 +21,9 @@ class AlunosAtivosAutodeclaradosController extends Controller
         $data = [];
 
         //tipo de vínculo
-        $vinculos = ['ALUNOGR', 'ALUNOPOS', 'ALUNOCEU', 'ALUNOPD'];
+        $vinculo = ['ALUNOGR', 'ALUNOPOS', 'ALUNOCEU', 'ALUNOPD'];
 
-        $vinculos = $request->route()->parameter('vinculo') ?? 'ALUNOGR';
+        $vinculo = $request->route()->parameter('vinculo') ?? 'ALUNOGR';
 
         $cores = Util::racas;
 
@@ -31,7 +31,7 @@ class AlunosAtivosAutodeclaradosController extends Controller
         foreach ($cores as $cor) {
             $query_por_cor = str_replace('__cor__', $cor, $query);
 
-            $query_por_cor = str_replace('__vinculo__', $vinculos, $query_por_cor);
+            $query_por_cor = str_replace('__vinculo__', $vinculo, $query_por_cor);
 
             $result = DB::fetch($query_por_cor);
             $data[$cor] = $result['computed'];
@@ -50,12 +50,12 @@ class AlunosAtivosAutodeclaradosController extends Controller
             'Parda',
             'Não informado',
         ]);
-        $vinculos = $this->vinculo;
+        $vinculo = $this->vinculo;
         $cores = Util::racas;
 
         $chart->dataset('Quantidade', 'bar', array_values($this->data));
 
-        return view('ativosAlunosAutodeclarados', compact('chart', 'vinculos', 'cores'));
+        return view('ativosAlunosAutodeclarados', compact('chart', 'vinculo', 'cores'));
     }
 
     public function export($format)

--- a/app/Utils/Util.php
+++ b/app/Utils/Util.php
@@ -29,6 +29,15 @@ class Util
         8051 => 'Letras',
     ];
 
+    const racas = [
+        'Indígena' => 1,
+        'Branca' => 2,
+        'Negra' => 3,
+        'Amarela' => 4,
+        'Parda' => 5,
+        'Não informado' => 6
+    ];
+
     public static function getDepartamentos() {
         return self::departamentos;
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -199,8 +199,8 @@ Route::get('/ativosDocentesPorFuncao', [AtivosDocentesPorFuncaoController::class
 Route::get('/ativosDocentesPorFuncao/export/{format}', [AtivosDocentesPorFuncaoController::class, 'export']);
 
 #totais de alunos ativos por cor/raça
-Route::get('/ativosAlunosAutodeclarados', [AlunosAtivosAutodeclaradosController::class, 'grafico']);
-Route::get('/ativosAlunosAutodeclarados/export/{format}', [AlunosAtivosAutodeclaradosController::class, 'export']);
+Route::get('/ativosAlunosAutodeclarados/{vinculo}', [AlunosAtivosAutodeclaradosController::class, 'grafico']);
+Route::get('/ativosAlunosAutodeclarados/export/{format}/{vinculo}', [AlunosAtivosAutodeclaradosController::class, 'export']);
 
 #totais de alunos ativos da graduação por tipo de ingresso
 Route::get('/ativosAlunosGradTipoIngresso', [AlunosAtivosGradTipoIngressoController::class, 'grafico']);


### PR DESCRIPTION
Consulta retorna alunos ativos de graduação, pós graduação, cultura e extensão e pós doutorado, autodeclarados por raça/cor.