### PR TITLE
Corrigindo erro - Alterando coluna json para nullable

### DIFF
--- a/database/migrations/2021_05_17_180037_alter_table_lattes_change_json.php
+++ b/database/migrations/2021_05_17_180037_alter_table_lattes_change_json.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterTableLattesChangeJson extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('lattes', function (Blueprint $table) {
+            $table->json('json')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('lattes', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
Alguns docentes não possuem lattes, então para esses casos não é preciso ter um json com as informações sobre o docente, o que faz o campo json ser NULL.