### PR TITLE
Correção no bloco 'Formação Acadêmica'

### DIFF
--- a/resources/views/programas/pessoa.blade.php
+++ b/resources/views/programas/pessoa.blade.php
@@ -253,7 +253,7 @@
                         @endif
                         @arr([$value,'ANO-DE-REALIZACAO']).
 
-                        @if(isset($value['PAGINA-INICIAL']))
+                        @if(isset($value['PAGINA-INICIAL']) && $value['PAGINA-INICIAL'] != '')
                             p.  @arr([$value,'PAGINA-INICIAL'])  - @arr([$value,'PAGINA-FINAL']).
                         @endif
                         
@@ -401,7 +401,10 @@
                         
                         
                         @arr([$value,'TITULO']). 
-                        @arr([$value,'ANO']) (@arr([$value,'EMISSORA']))
+                        @arr([$value,'ANO']) 
+                        @if(isset($value['EMISSORA']) && $value['EMISSORA'] != '')
+                        @arr([$value,'EMISSORA'])
+                        @endif
 
                     </li>
                 @endforeach

--- a/resources/views/programas/pessoa.blade.php
+++ b/resources/views/programas/pessoa.blade.php
@@ -748,17 +748,20 @@
                             @if(isset($val["ANO-DE-CONCLUSAO"]))
                             <li class="list-group-item">
                             @if(isset($val['NOME-CURSO']))
-                            Curso: @arr([$value,'NOME-CURSO']) <br>
+                            Curso: @arr([$val,'NOME-CURSO']) <br>
                             @endif
-                            Nome da Instituição: @arr([$value,'NOME-INSTITUICAO'])  <br>
+                            Nome da Instituição: @arr([$val,'NOME-INSTITUICAO'])  <br>
                             @if(isset($val['TITULO-DO-TRABALHO-DE-CONCLUSAO-DE-CURSO']) && $val['TITULO-DO-TRABALHO-DE-CONCLUSAO-DE-CURSO'] != null && $val['TITULO-DO-TRABALHO-DE-CONCLUSAO-DE-CURSO'] != '')
-                            Título: @arr([$value,'TITULO-DO-TRABALHO-DE-CONCLUSAO-DE-CURSO'])  <br> 
+                            Título: @arr([$val,'TITULO-DO-TRABALHO-DE-CONCLUSAO-DE-CURSO'])  <br> 
                             @endif
                             Ano de conclusão: 
                             @if(isset($val['ANO-DE-CONCLUSAO']) && $val['ANO-DE-CONCLUSAO'] != null && $val['ANO-DE-CONCLUSAO'] != '') 
-                                @arr([$value,'ANO-DE-CONCLUSAO']) 
+                                @arr([$val,'ANO-DE-CONCLUSAO']) <br>
                             @else
-                            Atual
+                            Atual <br>
+                            @endif
+                            @if(isset($val['STATUS-DO-CURSO']) && $val['STATUS-DO-CURSO'] != 'CONCLUIDO')
+                            Status do curso: <?= ucfirst(strtolower(Arr::get($val,'STATUS-DO-CURSO',""))) ?>
                             @endif
                             </li>
                             @endif


### PR DESCRIPTION
O array contido no parâmetro da diretiva @arr estava errado, então não estava sendo exibida nenhuma informação sobre Formação Acadêmica presente no Currículo Lattes da pessoa. Agora está sendo passado o valor correto no parâmetro. 