### PR TITLE
Fix usort() deprecation

### DIFF
--- a/app/Models/Programa.php
+++ b/app/Models/Programa.php
@@ -154,7 +154,7 @@ class Programa extends Model
 
         }
         usort($aux_pessoas, function ($a, $b) {
-            return $a['nompes'] > $b['nompes'];
+            return $a['nompes'] <=> $b['nompes'];
         });
 
         return $aux_pessoas;


### PR DESCRIPTION
Ao carregar a página dos docentes de cada programa, estava aparecendo um erro devido a ordenação por ordem alfabética no nome dos docentes:
usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero

A solução "correta", é o uso do operador nave especial <=>, ele retorna -1, 0 ou 1 quando o primeiro elemento é respectivamente menor, igual ou maior que o segundo elemento.
https://wiki.php.net/rfc/stable_sorting