### PR TITLE
Tratando erro na página de produção academica em programas

### DIFF
--- a/app/Http/Controllers/Api/ProgramaController.php
+++ b/app/Http/Controllers/Api/ProgramaController.php
@@ -9,7 +9,7 @@ use App\Models\Programa;
 use App\Utils\ReplicadoTemp;
 use Uspdev\Replicado\Posgraduacao;
 use Uspdev\Replicado\Lattes;
-
+use App\Models\Lattes as LattesModel;
 
 class ProgramaController extends Controller
 {
@@ -54,6 +54,8 @@ class ProgramaController extends Controller
     }
 
     public function docente($id_lattes, Request $request) {
+
+       
         $codpes = Lattes::retornarCodpesPorIDLattes($id_lattes);
 
         $filtro = Programa::getFiltro($request);        
@@ -73,7 +75,7 @@ class ProgramaController extends Controller
             $content
         );
     }
-    public function egresso($id_lattes, Request $request) {
+    public function egresso($id_lattes, Request $request) {       
         $codpes = Lattes::retornarCodpesPorIDLattes($id_lattes);
 
         $filtro = Programa::getFiltro($request);        

--- a/app/Http/Controllers/ProgramaController.php
+++ b/app/Http/Controllers/ProgramaController.php
@@ -72,6 +72,12 @@ class ProgramaController extends Controller
         $content = Programa::obterPessoa($codpes, $filtro,false, 'docentes');
         $section_show = request()->section ?? '';
 
+        
+        if(sizeof($content) == 0){
+            $request->session()->flash('alert-danger', "Dados do docente não encontrados");
+            return redirect("/programas");
+        }
+        
         return view('programas.pessoa',[
             'content' => $content,
             'section_show' => $section_show,
@@ -81,12 +87,18 @@ class ProgramaController extends Controller
         ]);
     }
 
+    
     public function discente($id_lattes, Request $request) {
         $codpes = Lattes::retornarCodpesPorIDLattes($id_lattes);
         $filtro = Programa::getFiltro($request);        
         $content = Programa::obterPessoa($codpes, $filtro, false, 'discentes');
         $section_show = request()->section ?? '';
         
+        if(sizeof($content) == 0){
+            $request->session()->flash('alert-danger', "Dados do discente não encontrados");
+            return redirect("/programas");
+        }
+
         return view('programas.pessoa',[
             'content' => $content,
             'section_show' => $section_show,
@@ -101,6 +113,11 @@ class ProgramaController extends Controller
         $content = Programa::obterPessoa($codpes, $filtro, false, 'egressos');
         $section_show = request()->section ?? '';
         
+        if(sizeof($content) == 0){
+            $request->session()->flash('alert-danger', "Dados do egresso não encontrados");
+            return redirect("/programas");
+        }
+
         return view('programas.pessoa',[
             'content' => $content,
             'section_show' => $section_show,
@@ -108,4 +125,5 @@ class ProgramaController extends Controller
             'form_action' => "/programas/egresso/$id_lattes"
         ]);
     }
+
 }

--- a/app/Models/Programa.php
+++ b/app/Models/Programa.php
@@ -162,15 +162,19 @@ class Programa extends Model
 
     public static function obterPessoa($codpes, $filtro, $api = false, $tipo_pessoa) {
 
+
+        
+
         $json_lattes = LattesModel::where('codpes',$codpes)->where('tipo_pessoa',$tipo_pessoa)->first();
             
         $lattes = $json_lattes ? json_decode($json_lattes->json,TRUE) : null;
-       
+        if($lattes == null) return [];
+
         $content['id_lattes'] = $lattes['id_lattes'] ?? null;
         $content['orcid'] = $lattes['orcid'] ?? null;
-        $content['nome'] = $lattes['nome'];
-        $content['resumo'] = $lattes['resumo'];
-        $content['linhas_pesquisa'] = $lattes['linhas_pesquisa'];
+        $content['nome'] = $lattes['nome'] ?? '';
+        $content['resumo'] = $lattes['resumo'] ?? '';
+        $content['linhas_pesquisa'] = $lattes['linhas_pesquisa'] ?? '';
 
             
         

--- a/resources/views/programas/index.blade.php
+++ b/resources/views/programas/index.blade.php
@@ -1,8 +1,33 @@
 @extends('laravel-usp-theme::master')
 
+
 @section('styles')
     <link rel="stylesheet" href="{{ asset('assets/css/programas.css') }}">
 @endsection('styles')
+
+
+@section('flash')
+    @if ($errors->any())
+    <div class="alert alert-danger">
+        <ul>
+            @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+    @endif
+
+  <div class="flash-message">
+    @foreach (['danger', 'warning', 'success', 'info'] as $msg)
+      @if(Session::has('alert-' . $msg))
+        <p class="alert alert-{{ $msg }}">{{ Session::get('alert-' . $msg) }}
+          <a href="#" class="close" data-dismiss="alert" aria-label="fechar">&times;</a>
+        </p>
+      @endif
+    @endforeach
+  </div>
+  
+@endsection
 
 
 @section('content')


### PR DESCRIPTION
Tratando o erro nas páginas programas/(docente/discente/egresso)/<id_lettes>. Dava 505 se não encontrasse dados com o id_lattes passado, agora exibe mensagem de erro no flash da view.