### PR TITLE
Corrigindo log comissao_pesquisa

### DIFF
--- a/app/Console/Commands/ReplicadoSyncCommand.php
+++ b/app/Console/Commands/ReplicadoSyncCommand.php
@@ -287,16 +287,13 @@ class ReplicadoSyncCommand extends Command
                 $comissao->cod_curso= isset($curso['codcur']) ? $curso['codcur'] : null;
                 $comissao->nome_curso= isset($curso['nome_curso']) ? $curso['nome_curso'] : null;
 
-                $comissao->cod_area= $ic['codare'];
-                $comissao->nome_area= $ic['nome_programa'];
+                $comissao->cod_area= $ic['codset'];
+                $comissao->nome_area= $ic['nome_setor'];
                 $comissao->tipo= 'IC';
 
                 $comissao->save();
             }
         }
-        
-    
-        
 
         if($pesquisa){
             foreach($pesquisa as $pd){

--- a/resources/views/pesquisa/iniciacao_cientifica.blade.php
+++ b/resources/views/pesquisa/iniciacao_cientifica.blade.php
@@ -28,7 +28,7 @@
 <div class="card">
   <div class="card-header">
     @if(!empty($nome_departamento))
-      <b>Iniciações científicas do departameno de {{$nome_departamento}}</b>
+      <b>Iniciações científicas do departamento de {{$nome_departamento}}</b>
     @else
       <b>Iniciações científicas do curso de {{$nome_curso}}</b>
     @endif

--- a/resources/views/pesquisa/pesquisadores_colab.blade.php
+++ b/resources/views/pesquisa/pesquisadores_colab.blade.php
@@ -14,7 +14,7 @@
 <div class="card">
   <div class="card-header">
     @if(!empty($nome_departamento))
-      <b>Pesquisadores colaboradores do departameno de {{$nome_departamento}}</b>
+      <b>Pesquisadores colaboradores do departamento de {{$nome_departamento}}</b>
     @else
       <b>Pesquisadores colaboradores do curso de {{$nome_curso}}</b>
     @endif

--- a/resources/views/pesquisa/pesquisas_pos_doutorando.blade.php
+++ b/resources/views/pesquisa/pesquisas_pos_doutorando.blade.php
@@ -13,7 +13,7 @@
 <div class="card">
   <div class="card-header">
     @if(!empty($nome_departamento))
-      <b>Pesquisas de pós doutorado do departameno de {{$nome_departamento}}</b>
+      <b>Pesquisas de pós doutorado do departamento de {{$nome_departamento}}</b>
     @else
       <b>Pesquisas de pós doutorado do curso de {{$nome_curso}}</b>
     @endif

--- a/resources/views/pesquisa/projetos_pesquisa.blade.php
+++ b/resources/views/pesquisa/projetos_pesquisa.blade.php
@@ -13,7 +13,7 @@
 <div class="card">
   <div class="card-header">
     @if(!empty($nome_departamento))
-      <b>Projetos de pesquisa dos docentes do departameno de {{$nome_departamento}}</b>
+      <b>Projetos de pesquisa dos docentes do departamento de {{$nome_departamento}}</b>
     @else
       <b>Projetos de pesquisa dos docentes do curso de {{$nome_curso}}</b>
     @endif


### PR DESCRIPTION
O método que estava sendo chamado para listar a produção dos alunos de Iniciação Cientifica, por departamento, havia sido removido do Replicado, pois na verdade estava listando a produção por Programas.
Um novo método foi criado no Replicado para retornar a produção por departamento para corrigir o erro.
