### PR TITLE
Correção query estagiarios

### DIFF
--- a/Queries/listar_estagiarios.sql
+++ b/Queries/listar_estagiarios.sql
@@ -2,6 +2,5 @@ SELECT V.codpes, V.nompes, S.nomset, V.dtainivin, V.dtafimvin
     from VINCULOPESSOAUSP V
     INNER JOIN dbo.SETOR S ON V.codset = S.codset 
     AND tipvin = 'ESTAGIARIORH' 
-    AND sitatl = 'A'
     AND V.dtainivin LIKE '%__ano__%'
     ORDER BY V.nompes


### PR DESCRIPTION
A listagem dos estagiários só estavam retornando aqueles que possuem o vínculo ativo, porém, como a listagem é feita por ano, é preciso retornar aqueles que já foram estagiário da FFLCH um dia e não são mais atualmente.
Para isso, eu retirei da query a condição sitatl = 'A', que fazia com que somente os estagiarios ativos fossem listados.