### PR TITLE
Definindo o ano atual como default na api de defesas

### DIFF
--- a/resources/views/defesas/index.blade.php
+++ b/resources/views/defesas/index.blade.php
@@ -10,7 +10,7 @@
     {{ Date('Y') }}
   @endif  
   </b>
-  <a href="{{ config('app.url') }}/api/defesas?ano={{request()->ano}}&codcur={{request()->codcur}}" class="export-json"><span data-toggle="tooltip" data-placement="left" title="Exportar em JSON" role="button"><img src="{{ asset('assets/img/json_icon.png') }}"></span></a>
+  <a href="{{ config('app.url') }}/api/defesas?ano={{request()->ano ?? date('Y')}}&codcur={{request()->codcur}}" class="export-json"><span data-toggle="tooltip" data-placement="left" title="Exportar em JSON" role="button"><img src="{{ asset('assets/img/json_icon.png') }}"></span></a>
   </div>
   <div class="card-body">
 


### PR DESCRIPTION
Em /defesas quando clicava em exportar json sem ter definido os filtros não trazia nada, então estamos definindo o ano atual como padrão, pois este é o comportamento ao clicar em expotar json na página principal.