### PR TITLE
Aumenta throttle da API

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -39,7 +39,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:60,1',
+            'throttle:600,1',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];


### PR DESCRIPTION
Aumenta Throttle da API para facilitar o consumo por outros sistemas.

Ex:
   Analytics:
        -> Perde muito tempo esperando o throttle expirar enquanto popula o banco de dados
        -> Não consegue rodar os testes completos pelo número de requisições por minuto feitas.