### PR TITLE
Corrige informações de estagiarios na página de 'Contato'

### DIFF
--- a/resources/views/contato.blade.php
+++ b/resources/views/contato.blade.php
@@ -15,9 +15,9 @@
     </p>
     
     <p><b><span class="title">Estagiários:</span><br></b>
-       @foreach(App\Models\Pessoa::where('tipo_vinculo', 'Estagiario')->where('codset', 558)->get()->toArray() as $pessoa)
-            {{ $pessoa['nompes'] }} - {{ $pessoa['email'] }} <br>
-       @endforeach
+        Andre de Queiroz Patrinicola - andrepatrinicola@usp.br<br>
+        Vinicius Fernandes Chagas - vinicius.chagas@usp.br<br>
+        Felipe de Assis Mello - felipe_de_assis@usp.br 
     </p>
 </div>
 


### PR DESCRIPTION
## Issue: 
Antes as informações dos estagiários eram geradas dinamicamente, porém, a query considerava todos os estagiários que ja passaram pelo EAIP e mantinha as informações de contato, fazendo com que os usuários por vezes mandassem e-mail com cópia para eles.

## Fix:
A tabela no banco de dados que a query referencia não possui nenhuma informacao relacionada a situacao desses vinculos (ex: 'ativo', 'encerrado') o que impede que a informacao seja renderizada dinamicamente para mostrar somente os ativos.

Modifiquei para que os estagiários sejam manualmente inseridos nas informacoes de contato direto no HTML, necessitando atualizações para qualquer alteração
